### PR TITLE
Add Deno v1.21.3 to toolchain versions

### DIFF
--- a/deno/private/deno_versions.bzl
+++ b/deno/private/deno_versions.bzl
@@ -9,4 +9,10 @@ DENO_VERSIONS = {
         "x86_64-pc-windows-msvc": "sha384-35YN6TKpT0L9qyRBmq48NucvyXEtHnkeC+txf2YZmmJTmOzrAKREA74BA0EZvpar",
         "x86_64-unknown-linux-gnu": "sha384-QgGOwTaetxY0h5HWCKc/3ZtBs4N/fgaaORthn7UcEv++Idm9W+ntCCZRwvBdwHPD",
     },
+    "1.21.3": {
+        "x86_64-apple-darwin": "sha384-dlMhWsYlaYw8ebgaSsIwWid4OngzIT7oMEWIgP70gSH/g4vwD2NLkl0at/0hY4/b",
+        "aarch64-apple-darwin": "sha384-uYvwRK0ng8nIfBIY/SlJlJOIlwnk96Bebprw9Jf7bxvnyfl0X/iolvZ38PiGQazk",
+        "x86_64-pc-windows-msvc": "sha384-BljBxezjflY9i64CnkCPAhHUbTxdEVF7JVfSpa6e7MfjXQPoaFAVAu9qavr/8gU5",
+        "x86_64-unknown-linux-gnu": "sha384-fqYpdOr10axKEG9b7KrMNwwlxdYnoqf+Mrcw/KoOzgNgRSB1sCUfRR3vcIvAcPlJ",
+    },
 }


### PR DESCRIPTION
Hashed using:

```shell
cat deno-$PLATFORM.zip | openssl dgst -sha384 -binary | openssl base64 -A
```

Verified this is working for my repository on a Mac M1.