### PR TITLE
Add Deno v1.24.1 to runtime version options

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,8 +20,8 @@ load("//deno:repositories.bzl", "deno_register_toolchains", "rules_deno_dependen
 rules_deno_dependencies()
 
 deno_register_toolchains(
-    name = "deno1_14",
-    deno_version = "1.14.2",
+    name = "deno1_24",
+    deno_version = "1.24.1",
 )
 
 # For running our own unit tests

--- a/deno/private/deno_versions.bzl
+++ b/deno/private/deno_versions.bzl
@@ -15,6 +15,12 @@ DENO_VERSIONS = {
         "x86_64-pc-windows-msvc": "sha384-BljBxezjflY9i64CnkCPAhHUbTxdEVF7JVfSpa6e7MfjXQPoaFAVAu9qavr/8gU5",
         "x86_64-unknown-linux-gnu": "sha384-fqYpdOr10axKEG9b7KrMNwwlxdYnoqf+Mrcw/KoOzgNgRSB1sCUfRR3vcIvAcPlJ",
     },
+    "1.24.1": {
+        "aarch64-apple-darwin": "sha384-u9R0SBbSc0CBOkGMnTKSlMKxPN+9nMGd3Q6HAzhaHqsQwvRDjtPmsF3wnn4obm78",
+        "x86_64-apple-darwin": "sha384-na/vkDZPKuPWQV5jMqpj1iCE+S3rv2j161yvzN03egyMnTa5nNJja0rJHlHIvVlo",
+        "x86_64-pc-windows-msvc": "sha384-L/SLyxIJhuEVGm4cq6ZiL3aaxfeNlIceJOdsR1KxIOy61AyKGjPVCz+/mMoXLopV",
+        "x86_64-unknown-linux-gnu": "sha384-LKP0QvtNVCa1qAQp4j+8u00IjPDjklNouc/SthOJ025tdz5nWrnWZapVYFadXv2e",
+    },
 }
 
 LATEST_VERSION = DENO_VERSIONS.keys()[-1]

--- a/deno/private/toolchains_repo.bzl
+++ b/deno/private/toolchains_repo.bzl
@@ -106,6 +106,6 @@ toolchains_repo = repository_rule(
     doc = """Creates a repository with toolchain definitions for all known platforms
      which can be registered or selected.""",
     attrs = {
-        "user_repository_name": attr.string(doc = "what the user chose for the base name, eg. deno1_14"),
+        "user_repository_name": attr.string(doc = "what the user chose for the base name, eg. deno1_24"),
     },
 )

--- a/deno/repositories.bzl
+++ b/deno/repositories.bzl
@@ -53,7 +53,7 @@ def deno_register_toolchains(name, **kwargs):
     - register a toolchain pointing at each platform
     Users can avoid this macro and do these steps themselves, if they want more control.
     Args:
-        name: base name for all created repos, like "deno1_14"
+        name: base name for all created repos, like "deno1_24"
         **kwargs: passed to each node_repositories call
     """
     for platform in PLATFORMS.keys():

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -3,10 +3,10 @@ sh_test(
     srcs = ["hello_world.test.sh"],
     data = [
         "hello_world.js",
-        "@deno1_14_toolchains//:resolved_toolchain",
+        "@deno1_24_toolchains//:resolved_toolchain",
     ],
     env = {
         "DENO": "$(DENO_PATH)",
     },
-    toolchains = ["@deno1_14_toolchains//:resolved_toolchain"],
+    toolchains = ["@deno1_24_toolchains//:resolved_toolchain"],
 )


### PR DESCRIPTION
This adds the latest version of the Deno runtime as a new toolchain version.