### PR TITLE
release: publish release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,13 @@ jobs:
           # Bazelisk will download bazel to here
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
-      - name: Prepare workspace snippet
-        run: .github/workflows/workspace_snippet.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
+      - name: Prepare release
+        run: .github/workflows/release_prep.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt
+          files: rules_deno-*.tar.gz
+          fail_on_unmatched_files: true

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset -o pipefail
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}
+# The prefix is chosen to match what GitHub generates for source archives
 PREFIX="rules_deno-${TAG:1}"
-SHA=$(git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip | shasum -a 256 | awk '{print $1}')
+ARCHIVE="rules_deno-$TAG.tar.gz"
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat << EOF
 WORKSPACE snippet:
@@ -16,7 +19,7 @@ http_archive(
     name = "aspect_rules_deno",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/aspect-build/rules_deno/archive/refs/tags/${TAG}.tar.gz",
+    url = "https://github.com/aspect-build/rules_deno/releases/download/${TAG}/${ARCHIVE}",
 )
 EOF
 


### PR DESCRIPTION
GitHub's stability guarantee for the archive is iffy, and we want metrics on downloads. See https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1411222578