### PR TITLE
chore: post permanently moved WARNING to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This repository has been **PERMANENTLY MOVED** to GitLab: https://gitlab.com/aspect-build/rules_deno
+
 # Bazel rules for deno
 
 This is very early experimental code to provide basic Deno support under Bazel.


### PR DESCRIPTION
The new home of rules_deno is on GitLab: https://gitlab.com/aspect-build/rules_deno.

New GitHub warning markdown is very nice: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

This repo will be archived after this lands.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)
